### PR TITLE
Add configuration for Jest and Enzyme

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-native-vector-icons": "latest"
   },
   "devDependencies": {
+    "@types/jest": "^23.3.2",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16.3": "^1.2.0",
     "jest": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "eject": "expo eject"
+    "eject": "expo eject",
+    "test": "jest"
   },
   "dependencies": {
     "expo": "^30.0.1",
@@ -19,5 +20,8 @@
     "enzyme": "^3.6.0",
     "jest": "^23.6.0",
     "jest-enzyme": "^6.1.2"
+  },
+  "jest": {
+    "preset": "react-native"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "devDependencies": {
     "enzyme": "^3.6.0",
     "jest": "^23.6.0",
-    "jest-enzyme": "^6.1.2"
+    "jest-enzyme": "^6.1.2",
+    "react-test-renderer": "^16.5.2"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
   },
   "devDependencies": {
     "enzyme": "^3.6.0",
+    "enzyme-adapter-react-16.3": "^1.2.0",
     "jest": "^23.6.0",
     "jest-enzyme": "^6.1.2",
+    "react-dom": "^16.5.2",
     "react-test-renderer": "^16.5.2"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "setupTestFrameworkScriptFile": "<rootDir>setupTests.js"
   }
 }

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,4 +1,12 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16.3';
 
+/*
+* See: https://github.com/airbnb/enzyme/issues/1501
+* * Needs react-dom
+* * recommended to use react-native-mock
+*
+* Might add react-native-mock/mock require later
+* */
+
 Enzyme.configure({ adapter: new Adapter() });

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16.3';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/test_examples/Foo.js
+++ b/test_examples/Foo.js
@@ -1,0 +1,24 @@
+/**
+ * Example class to be tested with enzyme
+ * Tested in Foo.test.js
+ * from https://github.com/airbnb/enzyme/blob/master/docs/guides/jest.md
+ * and https://github.com/vjwilson/enzyme-example-jest
+ */
+import React, { Component } from 'react';
+
+
+class Foo extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className="foo">
+        Bar
+      </div>
+    );
+  }
+}
+
+export default Foo;

--- a/test_examples/Foo.test.js
+++ b/test_examples/Foo.test.js
@@ -1,0 +1,28 @@
+/**
+ * Test Foo with enzyme
+ * Example from https://github.com/airbnb/enzyme/blob/master/docs/guides/jest.md
+ */
+import React from 'react';
+import { shallow, mount, render } from 'enzyme';
+
+import Foo from './Foo';
+
+describe('A suite', function() {
+  it('should render without throwing an error', function() {
+    expect(shallow(<Foo />).contains(<div className="foo">Bar</div>)).toBe(true);
+  });
+
+  it('should be selectable by class "foo"', function() {
+    expect(shallow(<Foo />).is('.foo')).toBe(true);
+  });
+
+  // React Native doesn't use a DOM, so mount() doesn't work in this environment
+  /*
+  it('should mount in a full DOM', function() {
+    expect(mount(<Foo />).find('.foo').length).toBe(1);
+  });
+*/
+  it('should render to static HTML', function() {
+    expect(render(<Foo />).text()).toEqual('Bar');
+  });
+});

--- a/test_examples/Intro.js
+++ b/test_examples/Intro.js
@@ -1,0 +1,37 @@
+// React Native jest example from https://jestjs.io/docs/en/tutorial-react-native
+// See other jest.js examples here: https://jestjs.io/docs/en/getting-started
+
+import React, {Component} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  instructions: {
+    color: '#333333',
+    marginBottom: 5,
+    textAlign: 'center',
+  },
+  welcome: {
+    fontSize: 20,
+    margin: 10,
+    textAlign: 'center',
+  },
+});
+
+export default class Intro extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.welcome}>Welcome to React Native!</Text>
+        <Text style={styles.instructions}>
+          This is a React Native snapshot test.
+        </Text>
+      </View>
+    );
+  }
+}

--- a/test_examples/Intro.test.js
+++ b/test_examples/Intro.test.js
@@ -1,0 +1,20 @@
+// Example Snapshot test of Intro
+// from https://jestjs.io/docs/en/tutorial-react-native
+// see https://jestjs.io/docs/en/getting-started for more examples
+
+// first jest run: generates a snapshot of Intro
+// the generated snapshots should be included in VCS
+// on any subsequent runs, compare output with stored snapshot
+// on failure, check if difference is intended or a bug
+// if intended, update snapshot by running jest -u
+
+
+import React from 'react';
+import Intro from "./Intro";
+
+import renderer from 'react-test-renderer';
+
+test('renders correctly', () => {
+  const tree = renderer.create(<Intro />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/test_examples/__snapshots__/Intro.test.js.snap
+++ b/test_examples/__snapshots__/Intro.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#F5FCFF",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "fontSize": 20,
+        "margin": 10,
+        "textAlign": "center",
+      }
+    }
+  >
+    Welcome to React Native!
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#333333",
+        "marginBottom": 5,
+        "textAlign": "center",
+      }
+    }
+  >
+    This is a React Native snapshot test.
+  </Text>
+</View>
+`;


### PR DESCRIPTION
Implements https://github.com/IT2810/it2810-webutvikling-h18-prosjekt-3-27/issues/6

- Adds required packages for Jest and Enzyme
- Create example test cases in test_examples folder (these can be deleted at a later date)
- Add setupTests.js, configures Enzyme. May be used for react native mocks at a later date.
